### PR TITLE
chore: ignore Spring Boot and testcontainers major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
       - "java"
       - "auto-approve"
       - "auto-merge"
+    ignore:
+      - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.testcontainers:testcontainers"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/deployment/database/crdr-reconciliation/src/function"


### PR DESCRIPTION
Adds dependabot ignore rules to prevent Spring Boot 4.x and testcontainers 2.x PRs from being opened.

- Spring Boot 4.x requires starter renames, explicit deps, modularized autoconfiguration
- testcontainers 2.x has breaking API changes

Also closed PRs #132, #135, #145, #148.