### PR TITLE
fix: bump deprecated SSM python3.7 runtime to 3.12 and harden restart-services

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -271,9 +271,9 @@ secrets-rotation: primary_region_orders-db primary_region_catalog-db
 restart-ecs-services:
 	@echo "Restarting ECS Services"
 	@if [ -z "${ENV}" ]; then \
-		./restart-services.sh --services catalog,orders; \
+		./restart-services.sh --region ${PRIMARY_REGION} --services catalog,orders; \
 	else \
-		./restart-services.sh --env ${ENV} --services catalog,orders; \
+		./restart-services.sh --env ${ENV} --region ${PRIMARY_REGION} --services catalog,orders; \
 	fi
 
 chaos-engineering: create-peer

--- a/deployment/database/crdr-reconciliation/src/cross-region-orders-db-ssm.yaml
+++ b/deployment/database/crdr-reconciliation/src/cross-region-orders-db-ssm.yaml
@@ -50,7 +50,7 @@ Resources:
           - name: CopyFailoverSnapshot
             action: 'aws:executeScript'
             inputs:
-              Runtime: python3.7
+              Runtime: python3.12
               Handler: script_handler
               InputPayload:                
                 SourceDBsnapshotArn: !Sub "{{SourceDBsnapshotArn}}"                

--- a/deployment/restart-services.sh
+++ b/deployment/restart-services.sh
@@ -3,6 +3,8 @@
 # Initialize variables
 ENV=""
 SERVICES=()
+# Default region falls back to the configured AWS_REGION/AWS_DEFAULT_REGION, then us-east-1
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
 
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
@@ -11,13 +13,17 @@ while [[ "$#" -gt 0 ]]; do
             ENV="$2"
             shift 2
             ;;
+        --region)
+            REGION="$2"
+            shift 2
+            ;;
         --services)
             IFS=',' read -r -a SERVICES <<< "$2"
             shift 2
             ;;
         *)
             echo "Unknown parameter passed: $1"
-            echo "Usage: $0 [--env <Env>] --services <Service1,Service2,...>"
+            echo "Usage: $0 [--env <Env>] [--region <Region>] --services <Service1,Service2,...>"
             exit 1
             ;;
     esac
@@ -37,12 +43,33 @@ get_cluster_arn() {
   else
     tag_value="mr-app-ecs-cluster${ENV}"
   fi
-  local cluster_arn
-  cluster_arn=$(aws resourcegroupstaggingapi get-resources \
+  # The Name tag can match several cluster ARNs: deleted clusters linger as
+  # INACTIVE tombstones (with their tags) after each stack create/delete cycle.
+  # Collect all matches, then keep only the ACTIVE one.
+  local matched_arns
+  matched_arns=$(aws resourcegroupstaggingapi get-resources \
+    --region "$REGION" \
     --tag-filters Key=Name,Values=$tag_value \
     --resource-type-filters ecs:cluster \
-    --query 'ResourceTagMappingList[0].ResourceARN' \
+    --query 'ResourceTagMappingList[].ResourceARN' \
     --output text)
+
+  if [ -z "$matched_arns" ]; then
+    echo ""
+    return
+  fi
+
+  local cluster_arn
+  cluster_arn=$(aws ecs describe-clusters \
+    --region "$REGION" \
+    --clusters $matched_arns \
+    --query "clusters[?status=='ACTIVE'].clusterArn | [0]" \
+    --output text)
+
+  # Normalize AWS CLI's "None" (no ACTIVE match) to empty string
+  if [ "$cluster_arn" = "None" ]; then
+    cluster_arn=""
+  fi
   echo "$cluster_arn"
 }
 
@@ -52,6 +79,7 @@ force_new_deployment() {
   local service_name=$2
 
   aws ecs update-service \
+    --region "$REGION" \
     --cluster "$cluster_arn" \
     --service "$service_name" \
     --force-new-deployment \
@@ -73,7 +101,8 @@ if [ -z "$CLUSTER_ARN" ]; then
   exit 1
 fi
 
-# Force a new deployment for each service in the list
+# Force a new deployment for each service in the list.
+# ECS service names carry the ${ENV} suffix (e.g. catalog-test), so append it.
 for service in "${SERVICES[@]}"; do
-  force_new_deployment "$CLUSTER_ARN" "$service"
+  force_new_deployment "$CLUSTER_ARN" "${service}${ENV}"
 done


### PR DESCRIPTION
- cross-region-orders-db-ssm.yaml: SSM Automation aws:executeScript no longer
  supports python3.7; bump to python3.12 (matches restore-reconcile-orders-ssm
  and secrets-rotation). Fixes crdr-orders-ssm CREATE failure:
  'python3.7 is not a supported runtime'.
- restart-services.sh: (1) aws CLI calls had no --region, failing with NoRegion
  when only AWS_PROFILE is set; add --region arg (defaults to AWS_REGION/
  AWS_DEFAULT_REGION then us-east-1). (2) The Name tag matches INACTIVE cluster
  tombstones left by prior stack create/delete cycles; select the ACTIVE cluster
  via describe-clusters instead of blindly taking the first tag match.
- Makefile: restart-ecs-services now passes --region $(PRIMARY_REGION).
